### PR TITLE
Update Adafruit_AHRS_NXPFusion.cpp resolves #10

### DIFF
--- a/src/Adafruit_AHRS_NXPFusion.cpp
+++ b/src/Adafruit_AHRS_NXPFusion.cpp
@@ -238,12 +238,12 @@ void Adafruit_NXPSensorFusion::update(float gx, float gy, float gz, float ax,
   // initial orientation lock to accelerometer and magnetometer eCompass
   // orientation
   // *********************************************************************************
-  if (fabsf(mx) >= 20.0f && fabsf(mx) >= 20.0f && fabsf(mx) >= 20.0f) {
+  if (fabsf(mx) <= 50.0f && fabsf(my) <= 50.0f && fabsf(mz) <= 50.0f) {
     ValidMagCal = 1;
   } else {
     ValidMagCal = 0;
   }
-
+  
   // do a once-only orientation lock after the first valid magnetic calibration
   if (ValidMagCal && !FirstOrientationLock) {
     // get the 6DOF orientation matrix and initial inclination angle

--- a/src/Adafruit_AHRS_NXPFusion.cpp
+++ b/src/Adafruit_AHRS_NXPFusion.cpp
@@ -243,7 +243,7 @@ void Adafruit_NXPSensorFusion::update(float gx, float gy, float gz, float ax,
   } else {
     ValidMagCal = 0;
   }
-  
+
   // do a once-only orientation lock after the first valid magnetic calibration
   if (ValidMagCal && !FirstOrientationLock) {
     // get the 6DOF orientation matrix and initial inclination angle


### PR DESCRIPTION
This ensures that the first orientation lock is performed, i.e. absolute heading is computed, where yaw = 0 means you head towards magnetic north