### PR TITLE
Variable delta time, orientation setters (ROS-like)

### DIFF
--- a/src/Adafruit_AHRS_FusionInterface.h
+++ b/src/Adafruit_AHRS_FusionInterface.h
@@ -31,11 +31,11 @@ public:
   virtual void begin(float sampleFrequency) = 0;
   virtual void update(float gx, float gy, float gz, float ax, float ay,
                       float az, float mx, float my, float mz) = 0;
-
   virtual float getRoll() = 0;
   virtual float getPitch() = 0;
   virtual float getYaw() = 0;
   virtual void getQuaternion(float *w, float *x, float *y, float *z) = 0;
+  virtual void setQuaternion(float w, float x, float y, float z) = 0;
 };
 
 #endif /* ADAFRUIT_AHRS_FUSIONINTERFACE_H_ */

--- a/src/Adafruit_AHRS_Madgwick.cpp
+++ b/src/Adafruit_AHRS_Madgwick.cpp
@@ -34,8 +34,8 @@
 //-------------------------------------------------------------------------------------------
 // AHRS algorithm update
 
-Adafruit_Madgwick::Adafruit_Madgwick() {
-  beta = betaDef;
+Adafruit_Madgwick::Adafruit_Madgwick(float gain) {
+  beta = gain;
   q0 = 1.0f;
   q1 = 0.0f;
   q2 = 0.0f;
@@ -45,7 +45,7 @@ Adafruit_Madgwick::Adafruit_Madgwick() {
 }
 
 void Adafruit_Madgwick::update(float gx, float gy, float gz, float ax, float ay,
-                               float az, float mx, float my, float mz) {
+                               float az, float mx, float my, float mz, float dt) {
   float recipNorm;
   float s0, s1, s2, s3;
   float qDot1, qDot2, qDot3, qDot4;
@@ -57,7 +57,7 @@ void Adafruit_Madgwick::update(float gx, float gy, float gz, float ax, float ay,
   // Use IMU algorithm if magnetometer measurement invalid (avoids NaN in
   // magnetometer normalisation)
   if ((mx == 0.0f) && (my == 0.0f) && (mz == 0.0f)) {
-    updateIMU(gx, gy, gz, ax, ay, az);
+    updateIMU(gx, gy, gz, ax, ay, az, dt);
     return;
   }
 
@@ -167,10 +167,10 @@ void Adafruit_Madgwick::update(float gx, float gy, float gz, float ax, float ay,
   }
 
   // Integrate rate of change of quaternion to yield quaternion
-  q0 += qDot1 * invSampleFreq;
-  q1 += qDot2 * invSampleFreq;
-  q2 += qDot3 * invSampleFreq;
-  q3 += qDot4 * invSampleFreq;
+  q0 += qDot1 * dt;
+  q1 += qDot2 * dt;
+  q2 += qDot3 * dt;
+  q3 += qDot4 * dt;
 
   // Normalise quaternion
   recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
@@ -185,7 +185,7 @@ void Adafruit_Madgwick::update(float gx, float gy, float gz, float ax, float ay,
 // IMU algorithm update
 
 void Adafruit_Madgwick::updateIMU(float gx, float gy, float gz, float ax,
-                                  float ay, float az) {
+                                  float ay, float az, float dt) {
   float recipNorm;
   float s0, s1, s2, s3;
   float qDot1, qDot2, qDot3, qDot4;
@@ -250,10 +250,10 @@ void Adafruit_Madgwick::updateIMU(float gx, float gy, float gz, float ax,
   }
 
   // Integrate rate of change of quaternion to yield quaternion
-  q0 += qDot1 * invSampleFreq;
-  q1 += qDot2 * invSampleFreq;
-  q2 += qDot3 * invSampleFreq;
-  q3 += qDot4 * invSampleFreq;
+  q0 += qDot1 * dt;
+  q1 += qDot2 * dt;
+  q2 += qDot3 * dt;
+  q3 += qDot4 * dt;
 
   // Normalise quaternion
   recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
@@ -263,6 +263,15 @@ void Adafruit_Madgwick::updateIMU(float gx, float gy, float gz, float ax,
   q3 *= recipNorm;
   anglesComputed = 0;
 }
+
+  void Adafruit_Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az,
+              float mx, float my, float mz){
+  	update(gx,gy,gz,ax,ay,az,mx,my,mz,invSampleFreq);
+  }
+  void Adafruit_Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float az){
+    	updateIMU(gx,gy,gz,ax,ay,az,invSampleFreq);
+  };
+
 
 //-------------------------------------------------------------------------------------------
 // Fast inverse square-root

--- a/src/Adafruit_AHRS_Madgwick.h
+++ b/src/Adafruit_AHRS_Madgwick.h
@@ -85,5 +85,11 @@ public:
     *y = q2;
     *z = q3;
   }
+  void setQuaternion(float w, float x, float y, float z) {
+    q0 = w;
+    q1 = x;
+    q2 = y;
+    q3 = z;
+  }
 };
 #endif

--- a/src/Adafruit_AHRS_Madgwick.h
+++ b/src/Adafruit_AHRS_Madgwick.h
@@ -40,11 +40,14 @@ private:
   //-------------------------------------------------------------------------------------------
   // Function declarations
 public:
-  Adafruit_Madgwick(void);
+  Adafruit_Madgwick(float gain);
   void begin(float sampleFrequency) { invSampleFreq = 1.0f / sampleFrequency; }
   void update(float gx, float gy, float gz, float ax, float ay, float az,
               float mx, float my, float mz);
   void updateIMU(float gx, float gy, float gz, float ax, float ay, float az);
+  void update(float gx, float gy, float gz, float ax, float ay, float az,
+              float mx, float my, float mz, float dt);
+  void updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt);
   // float getPitch(){return atan2f(2.0f * q2 * q3 - 2.0f * q0 * q1, 2.0f * q0 *
   // q0 + 2.0f * q3 * q3 - 1.0f);}; float getRoll(){return -1.0f * asinf(2.0f *
   // q1 * q3 + 2.0f * q0 * q2);}; float getYaw(){return atan2f(2.0f * q1 * q2

--- a/src/Adafruit_AHRS_Mahony.cpp
+++ b/src/Adafruit_AHRS_Mahony.cpp
@@ -37,9 +37,9 @@
 //-------------------------------------------------------------------------------------------
 // AHRS algorithm update
 
-Adafruit_Mahony::Adafruit_Mahony() {
-  twoKp = twoKpDef; // 2 * proportional gain (Kp)
-  twoKi = twoKiDef; // 2 * integral gain (Ki)
+Adafruit_Mahony::Adafruit_Mahony(float prop_gain, float int_gain) {
+  twoKp = prop_gain; // 2 * proportional gain (Kp)
+  twoKi = int_gain; // 2 * integral gain (Ki)
   q0 = 1.0f;
   q1 = 0.0f;
   q2 = 0.0f;
@@ -52,7 +52,7 @@ Adafruit_Mahony::Adafruit_Mahony() {
 }
 
 void Adafruit_Mahony::update(float gx, float gy, float gz, float ax, float ay,
-                             float az, float mx, float my, float mz) {
+                             float az, float mx, float my, float mz, float dt) {
   float recipNorm;
   float q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;
   float hx, hy, bx, bz;
@@ -126,9 +126,9 @@ void Adafruit_Mahony::update(float gx, float gy, float gz, float ax, float ay,
     // Compute and apply integral feedback if enabled
     if (twoKi > 0.0f) {
       // integral error scaled by Ki
-      integralFBx += twoKi * halfex * invSampleFreq;
-      integralFBy += twoKi * halfey * invSampleFreq;
-      integralFBz += twoKi * halfez * invSampleFreq;
+      integralFBx += twoKi * halfex * dt;
+      integralFBy += twoKi * halfey * dt;
+      integralFBz += twoKi * halfez * dt;
       gx += integralFBx; // apply integral feedback
       gy += integralFBy;
       gz += integralFBz;
@@ -145,9 +145,9 @@ void Adafruit_Mahony::update(float gx, float gy, float gz, float ax, float ay,
   }
 
   // Integrate rate of change of quaternion
-  gx *= (0.5f * invSampleFreq); // pre-multiply common factors
-  gy *= (0.5f * invSampleFreq);
-  gz *= (0.5f * invSampleFreq);
+  gx *= (0.5f * dt); // pre-multiply common factors
+  gy *= (0.5f * dt);
+  gz *= (0.5f * dt);
   qa = q0;
   qb = q1;
   qc = q2;
@@ -169,7 +169,7 @@ void Adafruit_Mahony::update(float gx, float gy, float gz, float ax, float ay,
 // IMU algorithm update
 
 void Adafruit_Mahony::updateIMU(float gx, float gy, float gz, float ax,
-                                float ay, float az) {
+                                float ay, float az, float dt) {
   float recipNorm;
   float halfvx, halfvy, halfvz;
   float halfex, halfey, halfez;
@@ -204,9 +204,9 @@ void Adafruit_Mahony::updateIMU(float gx, float gy, float gz, float ax,
     // Compute and apply integral feedback if enabled
     if (twoKi > 0.0f) {
       // integral error scaled by Ki
-      integralFBx += twoKi * halfex * invSampleFreq;
-      integralFBy += twoKi * halfey * invSampleFreq;
-      integralFBz += twoKi * halfez * invSampleFreq;
+      integralFBx += twoKi * halfex * dt;
+      integralFBy += twoKi * halfey * dt;
+      integralFBz += twoKi * halfez * dt;
       gx += integralFBx; // apply integral feedback
       gy += integralFBy;
       gz += integralFBz;
@@ -223,9 +223,9 @@ void Adafruit_Mahony::updateIMU(float gx, float gy, float gz, float ax,
   }
 
   // Integrate rate of change of quaternion
-  gx *= (0.5f * invSampleFreq); // pre-multiply common factors
-  gy *= (0.5f * invSampleFreq);
-  gz *= (0.5f * invSampleFreq);
+  gx *= (0.5f * dt); // pre-multiply common factors
+  gy *= (0.5f * dt);
+  gz *= (0.5f * dt);
   qa = q0;
   qb = q1;
   qc = q2;
@@ -242,6 +242,15 @@ void Adafruit_Mahony::updateIMU(float gx, float gy, float gz, float ax,
   q3 *= recipNorm;
   anglesComputed = 0;
 }
+
+void Adafruit_Mahony::update(float gx, float gy, float gz, float ax, float ay, float az,
+		  float mx, float my, float mz){
+	update(gx,gy,gz,ax,ay,az,mx,my,mz,invSampleFreq);
+}
+
+void Adafruit_Mahony::updateIMU(float gx, float gy, float gz, float ax, float ay, float az){
+	updateIMU(gx,gy,gz,ax,ay,az,invSampleFreq);
+};
 
 //-------------------------------------------------------------------------------------------
 // Fast inverse square-root

--- a/src/Adafruit_AHRS_Mahony.h
+++ b/src/Adafruit_AHRS_Mahony.h
@@ -78,6 +78,13 @@ public:
     *y = q2;
     *z = q3;
   }
+
+  void setQuaternion(float w, float x, float y, float z){
+    q0 = w;
+    q1 = x;
+    q2 = y;
+    q3 = z;
+  }
 };
 
 #endif

--- a/src/Adafruit_AHRS_Mahony.h
+++ b/src/Adafruit_AHRS_Mahony.h
@@ -37,11 +37,14 @@ private:
   // Function declarations
 
 public:
-  Adafruit_Mahony();
+  Adafruit_Mahony(float prop_gain, float int_gain);
   void begin(float sampleFrequency) { invSampleFreq = 1.0f / sampleFrequency; }
   void update(float gx, float gy, float gz, float ax, float ay, float az,
               float mx, float my, float mz);
   void updateIMU(float gx, float gy, float gz, float ax, float ay, float az);
+  void update(float gx, float gy, float gz, float ax, float ay, float az,
+              float mx, float my, float mz, float dt);
+  void updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt);
   float getRoll() {
     if (!anglesComputed)
       computeAngles();

--- a/src/Adafruit_AHRS_NXPFusion.h
+++ b/src/Adafruit_AHRS_NXPFusion.h
@@ -49,6 +49,13 @@ public:
     *z = qPl.q3;
   }
 
+  void setQuaternion(float w, float x, float y, float z) {
+    qPl.q0 = w;
+    qPl.q1 = x;
+    qPl.q2 = y;
+    qPl.q3 = z;
+  }
+
   typedef struct {
     float q0; // w
     float q1; // x


### PR DESCRIPTION
Hello,

this set of patches backports some features of Madgwick filter for ROS into these standalone libraries. 

- Variable delta time (overloaded C++ calls)
- Gains in constructors
- Orientation setters (useful to reset pose at power on using a reference obtained in some way by detecting the orientation of the gravity vector and magnetic field north)

Both Madgwick and Mahoni filters have been tested after the modifications in a custom, non-embedded, real-world project.