### PR TITLE
Add gravity vector output to Madgwick and Mahony filter

### DIFF
--- a/src/Adafruit_AHRS_FusionInterface.h
+++ b/src/Adafruit_AHRS_FusionInterface.h
@@ -90,6 +90,16 @@ public:
   virtual float getYaw() = 0;
   virtual void getQuaternion(float *w, float *x, float *y, float *z) = 0;
   virtual void setQuaternion(float w, float x, float y, float z) = 0;
+
+  /**************************************************************************/
+  /*!
+   * @brief Gets the current gravity vector of the sensor.
+   *
+   * @param x A float pointer to write the gravity vector x component to. In g.
+   * @param y A float pointer to write the gravity vector y component to. In g.
+   * @param z A float pointer to write the gravity vector z component to. In g.
+   */
+  virtual void getGravityVector(float *x, float *y, float *z) = 0;
 };
 
 #endif /* ADAFRUIT_AHRS_FUSIONINTERFACE_H_ */

--- a/src/Adafruit_AHRS_Madgwick.cpp
+++ b/src/Adafruit_AHRS_Madgwick.cpp
@@ -297,5 +297,8 @@ void Adafruit_Madgwick::computeAngles() {
   roll = atan2f(q0 * q1 + q2 * q3, 0.5f - q1 * q1 - q2 * q2);
   pitch = asinf(-2.0f * (q1 * q3 - q0 * q2));
   yaw = atan2f(q1 * q2 + q0 * q3, 0.5f - q2 * q2 - q3 * q3);
+  grav[0] = 2.0f * (q1 * q3 - q0 * q2);
+  grav[1] = 2.0f * (q0 * q1 + q2 * q3);
+  grav[2] = 2.0f * (q1 * q0 - 0.5f + q3 * q3);
   anglesComputed = 1;
 }

--- a/src/Adafruit_AHRS_Madgwick.h
+++ b/src/Adafruit_AHRS_Madgwick.h
@@ -31,9 +31,8 @@ private:
   float q2;
   float q3; // quaternion of sensor frame relative to auxiliary frame
   float invSampleFreq;
-  float roll;
-  float pitch;
-  float yaw;
+  float roll, pitch, yaw;
+  float grav[3];
   char anglesComputed;
   void computeAngles();
 
@@ -97,6 +96,11 @@ public:
     q1 = x;
     q2 = y;
     q3 = z;
+  }
+  void getGravityVector(float *x, float *y, float *z) {
+    *x = grav[0];
+    *y = grav[1];
+    *z = grav[2];
   }
 };
 #endif

--- a/src/Adafruit_AHRS_Mahony.cpp
+++ b/src/Adafruit_AHRS_Mahony.cpp
@@ -276,6 +276,9 @@ void Adafruit_Mahony::computeAngles() {
   roll = atan2f(q0 * q1 + q2 * q3, 0.5f - q1 * q1 - q2 * q2);
   pitch = asinf(-2.0f * (q1 * q3 - q0 * q2));
   yaw = atan2f(q1 * q2 + q0 * q3, 0.5f - q2 * q2 - q3 * q3);
+  grav[0] = 2.0f * (q1 * q3 - q0 * q2);
+  grav[1] = 2.0f * (q0 * q1 + q2 * q3);
+  grav[2] = 2.0f * (q1 * q0 - 0.5f + q3 * q3);
   anglesComputed = 1;
 }
 

--- a/src/Adafruit_AHRS_Mahony.h
+++ b/src/Adafruit_AHRS_Mahony.h
@@ -29,6 +29,7 @@ private:
       integralFBz; // integral error terms scaled by Ki
   float invSampleFreq;
   float roll, pitch, yaw;
+  float grav[3];
   char anglesComputed;
   static float invSqrt(float x);
   void computeAngles();
@@ -87,12 +88,16 @@ public:
     *y = q2;
     *z = q3;
   }
-
   void setQuaternion(float w, float x, float y, float z) {
     q0 = w;
     q1 = x;
     q2 = y;
     q3 = z;
+  }
+  void getGravityVector(float *x, float *y, float *z) {
+    *x = grav[0];
+    *y = grav[1];
+    *z = grav[2];
   }
 };
 

--- a/src/Adafruit_AHRS_NXPFusion.h
+++ b/src/Adafruit_AHRS_NXPFusion.h
@@ -116,12 +116,12 @@ public:
   /*!
    * @brief Get the gravity vector from the gyroscope values.
    *
-   * @param x The pointer to write the gravity vector x axis to. In g.
-   * @param y The pointer to write the gravity vector y axis to. In g.
-   * @param z The pointer to write the gravity vector z axis to. In g.
+   * @param x A float pointer to write the gravity vector x component to. In g.
+   * @param y A float pointer to write the gravity vector y component to. In g.
+   * @param z A float pointer to write the gravity vector z component to. In g.
    */
   /**************************************************************************/
-  void getGravityVector(float *x, float *y, float *z) const {
+  void getGravityVector(float *x, float *y, float *z) {
     *x = gSeGyMi[0];
     *y = gSeGyMi[1];
     *z = gSeGyMi[2];


### PR DESCRIPTION
This pull request adds the gravity vector as a standard output for all filters.
The calculation for the gravity vector is based on the gravity vector calculation from [xioTechnologies/Fusion](https://github.com/xioTechnologies/Fusion/blob/master/Fusion/FusionAhrs.c#L170) which is linked as a newer version of the Madgwick algorithm [here](https://x-io.co.uk/open-source-imu-and-ahrs-algorithms/) which is linked as a source in the Madgwick filter.

I originally also intended to add linear acceleration, however I decided against it since it would require caching the latest acceleration and forcing acceleration to always be in g or always in m/s^2.