### PR TITLE
Fix getGravityVector not calculating the actual values

### DIFF
--- a/src/Adafruit_AHRS_Madgwick.cpp
+++ b/src/Adafruit_AHRS_Madgwick.cpp
@@ -43,7 +43,7 @@ Adafruit_Madgwick::Adafruit_Madgwick(float gain) {
   q2 = 0.0f;
   q3 = 0.0f;
   invSampleFreq = 1.0f / sampleFreqDef;
-  anglesComputed = 0;
+  anglesComputed = false;
 }
 
 void Adafruit_Madgwick::update(float gx, float gy, float gz, float ax, float ay,

--- a/src/Adafruit_AHRS_Madgwick.h
+++ b/src/Adafruit_AHRS_Madgwick.h
@@ -33,7 +33,7 @@ private:
   float invSampleFreq;
   float roll, pitch, yaw;
   float grav[3];
-  bool anglesComputed;
+  bool anglesComputed = false;
   void computeAngles();
 
   //-------------------------------------------------------------------------------------------

--- a/src/Adafruit_AHRS_Madgwick.h
+++ b/src/Adafruit_AHRS_Madgwick.h
@@ -33,7 +33,7 @@ private:
   float invSampleFreq;
   float roll, pitch, yaw;
   float grav[3];
-  char anglesComputed;
+  bool anglesComputed;
   void computeAngles();
 
   //-------------------------------------------------------------------------------------------
@@ -98,6 +98,8 @@ public:
     q3 = z;
   }
   void getGravityVector(float *x, float *y, float *z) {
+    if (!anglesComputed)
+      computeAngles();
     *x = grav[0];
     *y = grav[1];
     *z = grav[2];

--- a/src/Adafruit_AHRS_Mahony.cpp
+++ b/src/Adafruit_AHRS_Mahony.cpp
@@ -49,7 +49,7 @@ Adafruit_Mahony::Adafruit_Mahony(float prop_gain, float int_gain) {
   integralFBx = 0.0f;
   integralFBy = 0.0f;
   integralFBz = 0.0f;
-  anglesComputed = 0;
+  anglesComputed = false;
   invSampleFreq = 1.0f / DEFAULT_SAMPLE_FREQ;
 }
 

--- a/src/Adafruit_AHRS_Mahony.h
+++ b/src/Adafruit_AHRS_Mahony.h
@@ -30,7 +30,7 @@ private:
   float invSampleFreq;
   float roll, pitch, yaw;
   float grav[3];
-  char anglesComputed;
+  bool anglesComputed;
   static float invSqrt(float x);
   void computeAngles();
 
@@ -95,6 +95,8 @@ public:
     q3 = z;
   }
   void getGravityVector(float *x, float *y, float *z) {
+    if (!anglesComputed)
+      computeAngles();
     *x = grav[0];
     *y = grav[1];
     *z = grav[2];

--- a/src/Adafruit_AHRS_Mahony.h
+++ b/src/Adafruit_AHRS_Mahony.h
@@ -30,7 +30,7 @@ private:
   float invSampleFreq;
   float roll, pitch, yaw;
   float grav[3];
-  bool anglesComputed;
+  bool anglesComputed = false;
   static float invSqrt(float x);
   void computeAngles();
 


### PR DESCRIPTION
This PR fixes a stupid mistake I missed in my last PR, that mistake being that I forgot to actually calculate the angles in getGravityVector.

I thought of that when planning this, so idk how I forgot.
I did do significant testing, but it seems like I didn't do any testing that doesn't use roll, pitch, and yaw at all.

## Changes
 * Fix getGravityVector not actually calculating any values
 * Change angelsComputed to a bool

## Questions
 * Is there a good reason for anglesComputed to be a char rather then a bool? I did some research and couldn't find one, but if there is I will undo that.
 * Is there a framework to add CI tests other then build tests with?
   I know that platformio has the ci command, however I have never used that so I don't really know what that does.
   Also adafruit doesn't seem to use platformio, so would that even be wanted?