### PR TITLE
fix warning emitted by old Adafruit_LSM303_U (archived repo)

### DIFF
--- a/examples/deprecated/ahrs_10dof/ahrs_10dof.ino
+++ b/examples/deprecated/ahrs_10dof/ahrs_10dof.ino
@@ -1,13 +1,14 @@
 #include <Wire.h>
 #include <Adafruit_Sensor.h>
-#include <Adafruit_LSM303_U.h>
+#include <Adafruit_LSM303_Accel.h>
+#include <Adafruit_LSM303DLH_Mag.h>
 #include <Adafruit_BMP085_U.h>
 #include <Adafruit_Simple_AHRS.h>
 
 // Create sensor instances.
-Adafruit_LSM303_Accel_Unified accel(30301);
-Adafruit_LSM303_Mag_Unified   mag(30302);
-Adafruit_BMP085_Unified       bmp(18001);
+Adafruit_LSM303_Accel_Unified  accel(30301);
+Adafruit_LSM303DLH_Mag_Unified mag(30302);
+Adafruit_BMP085_Unified        bmp(18001);
 
 // Create simple AHRS algorithm using the above sensors.
 Adafruit_Simple_AHRS          ahrs(&accel, &mag);

--- a/examples/deprecated/ahrs_9dof/ahrs_9dof.ino
+++ b/examples/deprecated/ahrs_9dof/ahrs_9dof.ino
@@ -1,11 +1,12 @@
 #include <Wire.h>
 #include <Adafruit_Sensor.h>
-#include <Adafruit_LSM303_U.h>
+#include <Adafruit_LSM303_Accel.h>
+#include <Adafruit_LSM303DLH_Mag.h>
 #include <Adafruit_Simple_AHRS.h>
 
 // Create sensor instances.
-Adafruit_LSM303_Accel_Unified accel(30301);
-Adafruit_LSM303_Mag_Unified   mag(30302);
+Adafruit_LSM303_Accel_Unified  accel(30301);
+Adafruit_LSM303DLH_Mag_Unified mag(30302);
 
 // Create simple AHRS algorithm using the above sensors.
 Adafruit_Simple_AHRS          ahrs(&accel, &mag);

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Includes motion calibration example sketches, as well as calibration o
 category=Sensors
 url=https://github.com/adafruit/Adafruit_AHRS
 architectures=*
-depends=Adafruit Unified Sensor, Adafruit LSM6DS, Adafruit LIS3MDL, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM9DS1 Library, Adafruit LSM9DS0 Library, Adafruit LSM303DLHC, Adafruit BMP085 Unified, Adafruit BluefruitLE nRF51, SdFat - Adafruit Fork, ArduinoJson, Adafruit SPIFlash, Adafruit Sensor Calibration
+depends=Adafruit Unified Sensor, Adafruit LSM6DS, Adafruit LIS3MDL, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM9DS1 Library, Adafruit LSM9DS0 Library, Adafruit BMP085 Unified, Adafruit BluefruitLE nRF51, SdFat - Adafruit Fork, ArduinoJson, Adafruit SPIFlash, Adafruit Sensor Calibration, Adafruit LSM303 Accel, Adafruit LSM303DLH Mag


### PR DESCRIPTION
Although 9dof and 10dof examples are in deprecated folders. These use the old Accel code that prevent ci to passed with esp32 (when compiling with all warnings). https://github.com/adafruit/Adafruit_AHRS/actions/runs/3290204490/jobs/5422730937#step:6:1171

This PR update these examples to use newer driver repo

PS: PR failed is due to insufficient name char which is fixed by https://github.com/adafruit/Adafruit_LSM303DLH_Mag/pull/9