### PR TITLE
Avoid warnings about `type-punned`

### DIFF
--- a/src/Adafruit_AHRS_Madgwick.cpp
+++ b/src/Adafruit_AHRS_Madgwick.cpp
@@ -280,15 +280,17 @@ void Adafruit_Madgwick::updateIMU(float gx, float gy, float gz, float ax,
 // Fast inverse square-root
 // See: http://en.wikipedia.org/wiki/Fast_inverse_square_root
 
-float Adafruit_Madgwick::invSqrt(float x) {
-  float halfx = 0.5f * x;
-  float y = x;
-  long i = *(long *)&y;
-  i = 0x5f3759df - (i >> 1);
-  y = *(float *)&i;
-  y = y * (1.5f - (halfx * y * y));
-  y = y * (1.5f - (halfx * y * y));
-  return y;
+float Adafruit_Madgwick::invSqrt(float x)
+{
+ 	float halfx = 0.5f * x;
+ 	union {
+ 	  float    f;
+ 	  uint32_t i;
+ 	} conv = { .f = x };
+ 	conv.i = 0x5f3759df - (conv.i >> 1);
+ 	conv.f *= 1.5f - (halfx * conv.f * conv.f);
+ 	conv.f *= 1.5f - (halfx * conv.f * conv.f);
+ 	return y;
 }
 
 //-------------------------------------------------------------------------------------------

--- a/src/Adafruit_AHRS_Mahony.cpp
+++ b/src/Adafruit_AHRS_Mahony.cpp
@@ -259,15 +259,17 @@ void Adafruit_Mahony::updateIMU(float gx, float gy, float gz, float ax,
 // Fast inverse square-root
 // See: http://en.wikipedia.org/wiki/Fast_inverse_square_root
 
-float Adafruit_Mahony::invSqrt(float x) {
-  float halfx = 0.5f * x;
-  float y = x;
-  long i = *(long *)&y;
-  i = 0x5f3759df - (i >> 1);
-  y = *(float *)&i;
-  y = y * (1.5f - (halfx * y * y));
-  y = y * (1.5f - (halfx * y * y));
-  return y;
+float Adafruit_Mahony::invSqrt(float x)
+{
+ 	float halfx = 0.5f * x;
+ 	union {
+ 	  float    f;
+ 	  uint32_t i;
+ 	} conv = { .f = x };
+ 	conv.i = 0x5f3759df - (conv.i >> 1);
+ 	conv.f *= 1.5f - (halfx * conv.f * conv.f);
+ 	conv.f *= 1.5f - (halfx * conv.f * conv.f);
+ 	return y;
 }
 
 //-------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hello,

  you used for estimating `inverse square root` old solution and modern compiler gives me warning:
```python
/Users/martin/Documents/Arduino/libraries/Adafruit_AHRS/src/Adafruit_AHRS_Mahony.cpp: In static member function 'static float Adafruit_Mahony::invSqrt(float)':
/Users/martin/Documents/Arduino/libraries/Adafruit_AHRS/src/Adafruit_AHRS_Mahony.cpp:265:22: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   long i = *(long *)&y;
                      ^
/Users/martin/Documents/Arduino/libraries/Adafruit_AHRS/src/Adafruit_AHRS_Mahony.cpp:267:18: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   y = *(float *)&i;
                  ^
/Users/martin/Documents/Arduino/libraries/Adafruit_AHRS/src/Adafruit_AHRS_Madgwick.cpp: In static member function 'static float Adafruit_Madgwick::invSqrt(float)':
/Users/martin/Documents/Arduino/libraries/Adafruit_AHRS/src/Adafruit_AHRS_Madgwick.cpp:286:22: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   long i = *(long *)&y;
                      ^
/Users/martin/Documents/Arduino/libraries/Adafruit_AHRS/src/Adafruit_AHRS_Madgwick.cpp:288:18: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   y = *(float *)&i;
                  ^
```

The better way is using `union` as a trick. Thanks.
