### PR TITLE
Update for LSM6DS3TRC

### DIFF
--- a/examples/calibrated_orientation/LSM6DS_LIS3MDL.h
+++ b/examples/calibrated_orientation/LSM6DS_LIS3MDL.h
@@ -2,8 +2,12 @@
 Adafruit_LIS3MDL lis3mdl;
 
 // Can change this to be LSM6DSOX or whatever ya like
+// For (older) Feather Sense with LSM6DS33, use this:
 #include <Adafruit_LSM6DS33.h>
 Adafruit_LSM6DS33 lsm6ds;
+// For (newer) Feather Sense with LSM6DS3TR-C, use this:
+//#include <Adafruit_LSM6DS3TRC.h>
+//Adafruit_LSM6DS3TRC lsm6ds;
 
 bool init_sensors(void) {
   if (!lsm6ds.begin_I2C() || !lis3mdl.begin_I2C()) {

--- a/examples/calibrated_orientation/LSM6DS_LIS3MDL.h
+++ b/examples/calibrated_orientation/LSM6DS_LIS3MDL.h
@@ -7,7 +7,7 @@ Adafruit_LIS3MDL lis3mdl;
 Adafruit_LSM6DS33 lsm6ds;
 // For (newer) Feather Sense with LSM6DS3TR-C, use this:
 //#include <Adafruit_LSM6DS3TRC.h>
-//Adafruit_LSM6DS3TRC lsm6ds;
+// Adafruit_LSM6DS3TRC lsm6ds;
 
 bool init_sensors(void) {
   if (!lsm6ds.begin_I2C() || !lis3mdl.begin_I2C()) {

--- a/examples/calibrated_orientation/calibrated_orientation.ino
+++ b/examples/calibrated_orientation/calibrated_orientation.ino
@@ -13,7 +13,7 @@
 Adafruit_Sensor *accelerometer, *gyroscope, *magnetometer;
 
 // uncomment one combo 9-DoF!
-#include "LSM6DS_LIS3MDL.h"  // can adjust to LSM6DS33, LSM6DS3U, LSM6DSOX...
+#include "LSM6DS_LIS3MDL.h"  // see the the LSM6DS_LIS3MDL file in this project to change board to LSM6DS33, LSM6DS3U, LSM6DSOX, etc
 //#include "LSM9DS.h"           // LSM9DS1 or LSM9DS0
 //#include "NXP_FXOS_FXAS.h"  // NXP 9-DoF breakout
 

--- a/examples/calibration/LSM6DS_LIS3MDL.h
+++ b/examples/calibration/LSM6DS_LIS3MDL.h
@@ -2,8 +2,12 @@
 Adafruit_LIS3MDL lis3mdl;
 
 // Can change this to be LSM6DS33 or whatever ya like
+// For (older) Feather Sense with LSM6DS33, use this:
 #include <Adafruit_LSM6DS33.h>
 Adafruit_LSM6DS33 lsm6ds;
+// For (newer) Feather Sense with LSM6DS3TR-C, use this:
+//#include <Adafruit_LSM6DS3TRC.h>
+//Adafruit_LSM6DS3TRC lsm6ds;
 
 bool init_sensors(void) {
   if (!lsm6ds.begin_I2C() || !lis3mdl.begin_I2C()) {

--- a/examples/calibration/LSM6DS_LIS3MDL.h
+++ b/examples/calibration/LSM6DS_LIS3MDL.h
@@ -7,7 +7,7 @@ Adafruit_LIS3MDL lis3mdl;
 Adafruit_LSM6DS33 lsm6ds;
 // For (newer) Feather Sense with LSM6DS3TR-C, use this:
 //#include <Adafruit_LSM6DS3TRC.h>
-//Adafruit_LSM6DS3TRC lsm6ds;
+// Adafruit_LSM6DS3TRC lsm6ds;
 
 bool init_sensors(void) {
   if (!lsm6ds.begin_I2C() || !lis3mdl.begin_I2C()) {


### PR DESCRIPTION
For #38. Adds `#includes` needed for newer Feather Sense boards using LSM6DS3TRC.

Tested using updated `calibration` and `calibrated_orientation` sketches.