### PR TITLE
Remove sensor dependencies

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Includes motion calibration example sketches, as well as calibration o
 category=Sensors
 url=https://github.com/adafruit/Adafruit_AHRS
 architectures=*
-depends=Adafruit Unified Sensor, Adafruit LSM6DS, Adafruit LIS3MDL, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM9DS1 Library, Adafruit LSM9DS0 Library, Adafruit BMP085 Unified, Adafruit BluefruitLE nRF51, SdFat - Adafruit Fork, ArduinoJson, Adafruit SPIFlash, Adafruit Sensor Calibration, Adafruit LSM303 Accel, Adafruit LSM303DLH Mag
+depends=Adafruit Unified Sensor, Adafruit Sensor Calibration


### PR DESCRIPTION
Addresses https://github.com/adafruit/Adafruit_AHRS/issues/33 and https://github.com/adafruit/Adafruit_AHRS/issues/37
- Removes sensor dependencies from `library.properties`. This removes unnecessary dependency installations for local development / CI builds

- Tests / examples need to be updated to require the external sensor / SPI  libraries