### PR TITLE
Fix Gravity Vector Calculation (#35)

### DIFF
--- a/src/Adafruit_AHRS_Madgwick.cpp
+++ b/src/Adafruit_AHRS_Madgwick.cpp
@@ -300,6 +300,6 @@ void Adafruit_Madgwick::computeAngles() {
   yaw = atan2f(q1 * q2 + q0 * q3, 0.5f - q2 * q2 - q3 * q3);
   grav[0] = 2.0f * (q1 * q3 - q0 * q2);
   grav[1] = 2.0f * (q0 * q1 + q2 * q3);
-  grav[2] = 2.0f * (q1 * q0 - 0.5f + q3 * q3);
+  grav[2] = 2.0f * (q0 * q0 - 0.5f + q3 * q3);
   anglesComputed = 1;
 }

--- a/src/Adafruit_AHRS_Mahony.cpp
+++ b/src/Adafruit_AHRS_Mahony.cpp
@@ -279,7 +279,7 @@ void Adafruit_Mahony::computeAngles() {
   yaw = atan2f(q1 * q2 + q0 * q3, 0.5f - q2 * q2 - q3 * q3);
   grav[0] = 2.0f * (q1 * q3 - q0 * q2);
   grav[1] = 2.0f * (q0 * q1 + q2 * q3);
-  grav[2] = 2.0f * (q1 * q0 - 0.5f + q3 * q3);
+  grav[2] = 2.0f * (q0 * q0 - 0.5f + q3 * q3);
   anglesComputed = 1;
 }
 


### PR DESCRIPTION
This PR corrects the bug described in #35, which results an incorrect value for the z-axis of the computed gravity vector in both the Madgwick and Mahony filters. The updated formula matches the one proposed in #35. 

I have tested the code on an IMU by inspecting the gravity vector to confirm that it aligns with the orientation of the IMU and ensuring that it is always a unit vector (which did not hold with the current bug).